### PR TITLE
Add error code to Mypy message

### DIFF
--- a/mypy_silent/cli.py
+++ b/mypy_silent/cli.py
@@ -6,7 +6,7 @@ import typer
 from mypy_silent.maho import add_type_ignore_comment
 from mypy_silent.maho import remove_type_ignore_comment
 from mypy_silent.parser import FilePosition
-from mypy_silent.parser import get_info_form_mypy_output
+from mypy_silent.parser import get_info_from_mypy_output
 from mypy_silent.parser import UNUSED_IGNORE_MESSAGES
 from mypy_silent.utils import get_lines
 
@@ -17,7 +17,7 @@ def mypy_silent(
     ),
 ) -> None:
     lines = get_lines(mypy_output_file)
-    infos = get_info_form_mypy_output(lines)
+    infos = get_info_from_mypy_output(lines)
     processed: Set[FilePosition] = set()
     for info in infos:
         if info.position in processed:
@@ -29,7 +29,7 @@ def mypy_silent(
         if info.message in UNUSED_IGNORE_MESSAGES:
             new_content = remove_type_ignore_comment(old_content)
         else:
-            new_content = add_type_ignore_comment(old_content)
+            new_content = add_type_ignore_comment(old_content, error_code=info.error_code)
         file_contents[info.position.line - 1] = new_content
         with open(info.position.filename, "w") as f:
             f.writelines(file_contents)

--- a/mypy_silent/maho.py
+++ b/mypy_silent/maho.py
@@ -1,9 +1,18 @@
-def add_type_ignore_comment(line: str) -> str:
+from typing import Optional
+
+
+def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
     # Workarounds for https://mypy.readthedocs.io/en/stable/common_issues.html#silencing-linters
+
+    type_ignore_comment = "# type: ignore"
+
+    if error_code:
+        type_ignore_comment += f"[{error_code}]"
+
     if "# noqa" in line:
-        return line.replace("# noqa", "# type: ignore # noqa", 1)
+        return line.replace("# noqa", f"{type_ignore_comment} # noqa", 1)
     content_without_crlf = line.rstrip("\r\n")
-    return content_without_crlf + "  # type: ignore" + line[len(content_without_crlf) :]
+    return content_without_crlf + f"  {type_ignore_comment}" + line[len(content_without_crlf) :]
 
 
 def remove_type_ignore_comment(line: str) -> str:

--- a/tests/test_maho.py
+++ b/tests/test_maho.py
@@ -15,7 +15,13 @@ from mypy_silent.maho import remove_type_ignore_comment
     ),
 )
 def test_add_type_ignore_comment(input: str, output: str) -> None:
-    assert add_type_ignore_comment(input) == output
+    assert add_type_ignore_comment(input, error_code=None) == output
+
+
+def test_add_type_ignore_comment_with_error_code() -> None:
+    input = "host, port, protocol = m.groups()\r\n"
+    output = "host, port, protocol = m.groups()  # type: ignore[misc]\r\n"
+    assert add_type_ignore_comment(input, error_code="misc") == output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 
 from mypy_silent.parser import FilePosition
-from mypy_silent.parser import get_info_form_mypy_output
+from mypy_silent.parser import get_info_from_mypy_output
 from mypy_silent.parser import MypyMessage
 
 
@@ -14,20 +14,22 @@ from mypy_silent.parser import MypyMessage
         (
             [
                 "utils/template.py:49: error: Cannot assign to a method",
-                "utils/template.py:53: error: Statement is unreachable",
+                "utils/template.py:53: error: Statement is unreachable [unreachable]",
             ],
             [
                 MypyMessage(
                     position=FilePosition(filename="utils/template.py", line=49),
                     message="error: Cannot assign to a method",
+                    error_code=None,
                 ),
                 MypyMessage(
                     position=FilePosition(filename="utils/template.py", line=53),
                     message="error: Statement is unreachable",
+                    error_code="unreachable",
                 ),
             ],
         ),
     ),
 )
-def test_get_info_form_mypy_output(input: List[str], output: List[MypyMessage]) -> None:
-    assert list(get_info_form_mypy_output(input)) == output
+def test_get_info_from_mypy_output(input: List[str], output: List[MypyMessage]) -> None:
+    assert list(get_info_from_mypy_output(input)) == output


### PR DESCRIPTION
This PR adds support for error codes in Mypy.

So instead of just adding `# type: ignore` we now add `# type: ignore[misc]` :)

I also changed the regex to use named groups so it is easier to read (and thanks to @BryceBeagle for helping me with it) :D

Ideally we should add support for error codes when removing type ignore comments, but I can do that in another PR :)