### PR TITLE
Add support for removing unused type ignores with error codes

### DIFF
--- a/mypy_silent/maho.py
+++ b/mypy_silent/maho.py
@@ -1,4 +1,11 @@
+import re
 from typing import Optional
+
+
+
+_type_ignore_re = re.compile(
+    r"# type: ignore(\[[a-z, \-]+\])?"
+)
 
 
 def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
@@ -22,7 +29,7 @@ def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
 def remove_type_ignore_comment(line: str) -> str:
     content_without_crlf = line.rstrip("\r\n")
     return (
-        content_without_crlf.replace("# type: ignore", "#")
+        _type_ignore_re.sub("#", content_without_crlf)
         .rstrip()
         .rstrip("#")
         .rstrip()

--- a/mypy_silent/maho.py
+++ b/mypy_silent/maho.py
@@ -2,10 +2,7 @@ import re
 from typing import Optional
 
 
-
-_type_ignore_re = re.compile(
-    r"# type: ignore(\[[a-z, \-]+\])?"
-)
+_type_ignore_re = re.compile(r"# type: ignore(\[[a-z, \-]+\])?")
 
 
 def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
@@ -29,9 +26,6 @@ def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
 def remove_type_ignore_comment(line: str) -> str:
     content_without_crlf = line.rstrip("\r\n")
     return (
-        _type_ignore_re.sub("#", content_without_crlf)
-        .rstrip()
-        .rstrip("#")
-        .rstrip()
+        _type_ignore_re.sub("#", content_without_crlf).rstrip().rstrip("#").rstrip()
         + line[len(content_without_crlf) :]
     )

--- a/tests/test_maho.py
+++ b/tests/test_maho.py
@@ -32,6 +32,8 @@ def test_add_type_ignore_comment_with_error_code() -> None:
             "        host, port, protocol = m.groups()\r\n",
         ),
         ("# type: ignore. very good", "#. very good"),
+        ("# type: ignore[misc]. very good", "#. very good"),
+        ("# type: ignore[misc, arg-type]. very good", "#. very good"),
     ),
 )
 def test_remove_type_ignore_comment(input: str, output: str) -> None:


### PR DESCRIPTION
Continuation of #41 😊 

Now these comments are removed properly:

```
b: str = "a"  # type: ignore[arg-type]
```