### PR TITLE
Add support for multiple error codes

### DIFF
--- a/mypy_silent/cli.py
+++ b/mypy_silent/cli.py
@@ -20,8 +20,6 @@ def mypy_silent(
     infos = get_info_from_mypy_output(lines)
     processed: Set[FilePosition] = set()
     for info in infos:
-        if info.position in processed:
-            continue
         with open(info.position.filename) as f:
             file_contents = f.readlines()
 

--- a/mypy_silent/maho.py
+++ b/mypy_silent/maho.py
@@ -25,7 +25,7 @@ def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
         content_without_crlf = _type_ignore_re.sub("", content_without_crlf)
 
     if error_codes:
-        type_ignore_comment += f"[{', '.join(error_codes)}]"
+        type_ignore_comment += f"[{', '.join(sorted(error_codes))}]"
 
     # Workarounds for https://mypy.readthedocs.io/en/stable/common_issues.html#silencing-linters
     if "# noqa" in content_without_crlf:

--- a/mypy_silent/maho.py
+++ b/mypy_silent/maho.py
@@ -1,26 +1,39 @@
 import re
 from typing import Optional
+from typing import Set
 
 
-_type_ignore_re = re.compile(r"# type: ignore(\[[a-z, \-]+\])?")
+_type_ignore_re = re.compile(r"# type: ignore(\[(?P<error_code>[a-z, \-]+)\])?")
 
 
 def add_type_ignore_comment(line: str, error_code: Optional[str]) -> str:
-    # Workarounds for https://mypy.readthedocs.io/en/stable/common_issues.html#silencing-linters
+    content_without_crlf = line.rstrip("\r\n")
+    line_ending = line[len(content_without_crlf) :]
+    error_codes: Set[str] = set()
+
+    if error_code is not None:
+        error_codes.add(error_code)
 
     type_ignore_comment = "# type: ignore"
 
-    if error_code:
-        type_ignore_comment += f"[{error_code}]"
+    match = _type_ignore_re.search(content_without_crlf)
 
-    if "# noqa" in line:
-        return line.replace("# noqa", f"{type_ignore_comment} # noqa", 1)
-    content_without_crlf = line.rstrip("\r\n")
-    return (
-        content_without_crlf
-        + f"  {type_ignore_comment}"
-        + line[len(content_without_crlf) :]
-    )
+    if match:
+        if match.group("error_code"):
+            error_codes.update(match.group("error_code").split(","))
+
+        content_without_crlf = _type_ignore_re.sub("", content_without_crlf)
+
+    if error_codes:
+        type_ignore_comment += f"[{', '.join(error_codes)}]"
+
+    # Workarounds for https://mypy.readthedocs.io/en/stable/common_issues.html#silencing-linters
+    if "# noqa" in content_without_crlf:
+        return content_without_crlf.replace(
+            "# noqa", f"{type_ignore_comment} # noqa", 1
+        )
+
+    return content_without_crlf.rstrip() + f"  {type_ignore_comment}" + line_ending
 
 
 def remove_type_ignore_comment(line: str) -> str:

--- a/tests/test_maho.py
+++ b/tests/test_maho.py
@@ -71,7 +71,7 @@ def test_add_type_ignore_with_existing_comment_with_code() -> None:
 
     assert (
         add_type_ignore_comment(input, error_code="arg-type")
-        == "host, port, protocol = m.groups()  # type: ignore[misc, arg-type]\r\n"
+        == "host, port, protocol = m.groups()  # type: ignore[arg-type, misc]\r\n"
     )
     assert (
         add_type_ignore_comment(input, error_code=None)

--- a/tests/test_maho.py
+++ b/tests/test_maho.py
@@ -51,3 +51,29 @@ def test_add_type_ignore_comment(
 )
 def test_remove_type_ignore_comment(input: str, output: str) -> None:
     assert remove_type_ignore_comment(input) == output
+
+
+def test_add_type_ignore_with_existing_comment() -> None:
+    input = "host, port, protocol = m.groups()  # type: ignore\r\n"
+
+    assert (
+        add_type_ignore_comment(input, error_code=None)
+        == "host, port, protocol = m.groups()  # type: ignore\r\n"
+    )
+    assert (
+        add_type_ignore_comment(input, error_code="arg-type")
+        == "host, port, protocol = m.groups()  # type: ignore[arg-type]\r\n"
+    )
+
+
+def test_add_type_ignore_with_existing_comment_with_code() -> None:
+    input = "host, port, protocol = m.groups()  # type: ignore[misc]\r\n"
+
+    assert (
+        add_type_ignore_comment(input, error_code="arg-type")
+        == "host, port, protocol = m.groups()  # type: ignore[misc, arg-type]\r\n"
+    )
+    assert (
+        add_type_ignore_comment(input, error_code=None)
+        == "host, port, protocol = m.groups()  # type: ignore[misc]\r\n"
+    )


### PR DESCRIPTION
Another one 😊 

This PR improves the code that adds type ignores by adding support for multiple error codes, for example this line:

```python
a: str = len(1)
```

returns the following errors:

```
mypy-silent ❯ poetry run mypy hello.py
hello.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
hello.py:1: error: Argument 1 to "len" has incompatible type "int"; expected "Sized"
Found 2 errors in 1 file (checked 1 source file)
```

With this PR the result of mypy silent becomes this:

```python
a: str = len(1)   # type: ignore[assignment, arg-type]
```

